### PR TITLE
feat(logs): add configurable expiry for ALB and CloudFront logs and added switch to create CloudFront logs 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -215,6 +215,7 @@ module "l7_loadbalancer" {
   security_groups = [module.security_groups[0].loadbalancer_sg]
 
   enable_alb_logs            = var.enable_alb_logs
+  alb_logs_expiration        = var.alb_logs_expiration
   enable_deletion_protection = var.enable_alb_deletion_protection
 
   enable_custom_domain = var.enable_custom_domain
@@ -288,6 +289,9 @@ module "cloudfront_cdn" {
 
   calculated_zone_id           = var.enable_custom_domain ? module.dns_and_certificates[0].hosted_zone_id : ""
   create_route53_domain_record = var.enable_custom_domain
+
+  enable_cf_logs     = var.enable_cf_logs
+  cf_logs_expiration = var.cf_logs_expiration
 
   enable_s3_for_static_website                                   = var.enable_s3_for_static_website
   s3_static_website_bucket_cf_function_arn                       = var.s3_static_website_bucket_cf_function_arn

--- a/modules/cloudfront_cdn/variables.tf
+++ b/modules/cloudfront_cdn/variables.tf
@@ -135,3 +135,15 @@ variable "enable_environment_hibernation_admin_website" {
   description = "Select true to enable sleep environment hibernation."
   default     = false
 }
+
+variable "enable_cf_logs" {
+  type        = bool
+  description = "Select to enable storing CloudFront logs in s3 bucket."
+  default     = true
+}
+
+variable "cf_logs_expiration" {
+  description = "Lifetime, in days, of the objects that are subject to the rule"
+  type        = number
+  default     = 90
+}

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -85,7 +85,7 @@ module "log_bucket" {
   count = var.enable_alb_logs ? 1 : 0
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.1.1"
+  version = "4.6.0"
 
   bucket = "${var.solution_name}-alb-logs-s3-bucket-${random_string.random_s3_alb_logs_postfix.result}"
   acl    = "log-delivery-write"
@@ -97,6 +97,21 @@ module "log_bucket" {
 
   attach_elb_log_delivery_policy = true # Required for ALB logs
   #attach_lb_log_delivery_policy  = true # Required for ALB/NLB logs
+
+  lifecycle_rule = [
+    {
+      id     = "alb-logs-${var.alb_logs_expiration}-expiration"
+      status = "Enabled"
+
+      expiration = {
+        days = var.alb_logs_expiration
+      }
+
+      filter = {
+        prefix = ""
+      }
+    }
+  ]
 
   attach_deny_insecure_transport_policy = true
   attach_require_latest_tls_policy      = true

--- a/modules/loadbalancer/variables.tf
+++ b/modules/loadbalancer/variables.tf
@@ -47,3 +47,9 @@ variable "domain_name" {
   description = ""
   type        = string
 }
+
+variable "alb_logs_expiration" {
+  description = "Lifetime, in days, of the objects that are subject to the rule"
+  type        = number
+  default     = 90
+}

--- a/variables.tf
+++ b/variables.tf
@@ -168,6 +168,11 @@ variable "enable_alb_logs" {
   description = "Select to enable storing alb logs in s3 bucket."
   default     = false
 }
+variable "alb_logs_expiration" {
+  description = "Lifetime, in days, of the objects that are subject to the rule"
+  type        = number
+  default     = 90
+}
 
 variable "enable_alb_deletion_protection" {
   type        = bool
@@ -363,6 +368,18 @@ variable "s3_static_website_bucket_cf_lambda_at_edge_viewer_response_arn" {
   type        = string
   description = "String that defines Origin Response Function type of Lamnda@Edge for static website bucket."
   default     = ""
+}
+
+variable "enable_cf_logs" {
+  type        = bool
+  description = "Select to enable storing CloudFront logs in s3 bucket."
+  default     = true
+}
+
+variable "cf_logs_expiration" {
+  description = "Lifetime, in days, of the objects that are subject to the rule"
+  type        = number
+  default     = 90
 }
 
 variable "disable_custom_error_response" {


### PR DESCRIPTION
This commit adds the following features:

- Enable/disable option forCloudFront logs, per default Enable
- Implement configurable expiry for ALB and CloudFront logs stored in S3 bucket
- Set default expiry period to 90 days for both log types
