### PR TITLE
feat(spa): add Lambda@Edge support for SPAs in S3 static website

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -295,7 +295,7 @@ module "cloudfront_cdn" {
 
   enable_s3_for_static_website                                   = var.enable_s3_for_static_website
   s3_static_website_bucket_cf_function_arn                       = var.s3_static_website_bucket_cf_function_arn
-  s3_static_website_bucket_cf_lambda_at_edge_origin_request_arn  = var.s3_static_website_bucket_cf_lambda_at_edge_origin_request_arn
+  s3_static_website_bucket_cf_lambda_at_edge_origin_request_arn  = try("${module.lambda_at_edge[0].lambda_at_edge_arn}:${module.lambda_at_edge[0].lambda_at_edge_version}", "")
   s3_static_website_bucket_cf_lambda_at_edge_viewer_request_arn  = var.s3_static_website_bucket_cf_lambda_at_edge_viewer_request_arn
   s3_static_website_bucket_cf_lambda_at_edge_origin_response_arn = var.s3_static_website_bucket_cf_lambda_at_edge_origin_response_arn
   s3_static_website_bucket_cf_lambda_at_edge_viewer_response_arn = var.s3_static_website_bucket_cf_lambda_at_edge_viewer_response_arn
@@ -317,6 +317,17 @@ module "cloudfront_cdn" {
 
   s3_admin_website_url                         = try(module.global_scale_down[0].s3_admin_website_url, "")
   enable_environment_hibernation_admin_website = var.enable_environment_hibernation_sleep_schedule
+}
+
+module "lambda_at_edge" {
+  count = var.enable_spa ? 1 : 0
+
+  source        = "./modules/lambda_at_edge"
+  solution_name = var.solution_name
+
+  providers = {
+    aws.useast1 = aws.useast1
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/lambda_at_edge/lambda_at_edge_functions/origin_request.mjs
+++ b/modules/lambda_at_edge/lambda_at_edge_functions/origin_request.mjs
@@ -1,0 +1,15 @@
+import * as path from 'path';
+
+export const handler = async (event, context, callback) => {
+  const { request } = event.Records[0].cf;
+  const parsedPath = path.parse(request.uri);
+
+  // Check if the URI path does not specify a file extension
+  if (parsedPath.ext === '') {
+      request.uri = '/index.html';
+  }
+
+  console.log("REQUEST_URI" + request.uri);
+
+  callback(null, request);
+};

--- a/modules/lambda_at_edge/main.tf
+++ b/modules/lambda_at_edge/main.tf
@@ -1,14 +1,14 @@
 data "archive_file" "lambda_at_edge" {
   type        = "zip"
-  source_file = "${var.source_path}/${var.file_name}.mjs"
-  output_path = "${var.source_path}/${var.file_name}.zip"
+  source_file = "${path.module}/lambda_at_edge_functions/origin_request.mjs"
+  output_path = "${path.module}/lambda_at_edge_functions/origin_request.zip"
 }
 
 #tfsec:ignore:aws-lambda-enable-tracing
 resource "aws_lambda_function" "lambda_at_edge" {
   # If the file is not in the current working directory you will need to include a
   # path.module in the filename.
-  filename      = "${var.source_path}/${var.file_name}.zip"
+  filename      = "${path.module}/lambda_at_edge_functions/origin_request.zip"
   function_name = "${var.solution_name}-${var.file_name}-cf-modify-response-header"
   description   = "lambda@edge function for the default error behaviour"
 

--- a/modules/lambda_at_edge/variables.tf
+++ b/modules/lambda_at_edge/variables.tf
@@ -5,11 +5,5 @@ variable "solution_name" {
 variable "file_name" {
   type        = string
   description = "String that defines Viewer Response Function type of Lamnda@Edge for static website bucket."
-  default     = "viewer__request"
-}
-
-variable "source_path" {
-  type        = string
-  description = "String that defines Origin Response Function type of Lamnda@Edge for static website bucket."
-  default     = "/lambda_at_edge/"
+  default     = "origin_request"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -388,6 +388,12 @@ variable "disable_custom_error_response" {
   description = "Needs to be enabled in cases where API responses are masked by a custom error response on 404."
 }
 
+variable "enable_spa" {
+  type        = bool
+  default     = false
+  description = "Enable Viewer Request Function type of Lamnda@Edge for static website bucket."
+}
+
 variable "enable_ecs_exec" {
   description = "Enables ECS Exec which allows SSH into containers for debugging purposes."
   type        = bool


### PR DESCRIPTION
Add a new Lambda@Edge function to handle SPA routing by redirecting requests without file extensions to index.html. Implement new enable_spa parameter to conditionally deploy the Lambda function for S3 static websites and CloudFront Distribution.