### PR TITLE
feat: add response_headers_policy_id parameter to CloudFront distribution for S3 website behaviour

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -308,7 +308,8 @@ module "cloudfront_cdn" {
   s3_solution_bucket_cf_behaviours = var.s3_solution_bucket_cf_behaviours
   disable_custom_error_response    = var.disable_custom_error_response
 
-  web_acl_id = var.web_acl_id
+  web_acl_id                 = var.web_acl_id
+  response_headers_policy_id = var.response_headers_policy_id
 
   # when custom_elb_cf_path_patterns is not given by developer, it is being calculated (calculation only works in single state setups)
   custom_elb_cf_path_patterns = length(var.custom_elb_cf_path_patterns) == 0 ? local.app_component_paths : var.custom_elb_cf_path_patterns

--- a/modules/cloudfront_cdn/main.tf
+++ b/modules/cloudfront_cdn/main.tf
@@ -141,6 +141,8 @@ locals {
       default_ttl = 0
       max_ttl     = 0
 
+      response_headers_policy_id = var.response_headers_policy_id
+
       use_forwarded_values     = false
       origin_request_policy_id = data.aws_cloudfront_origin_request_policy.ManagedCORSS3Origin.id
       cache_policy_id          = data.aws_cloudfront_cache_policy.ManagedCachingDisabled.id

--- a/modules/cloudfront_cdn/variables.tf
+++ b/modules/cloudfront_cdn/variables.tf
@@ -154,3 +154,10 @@ variable "web_acl_id" {
   default     = null
   description = "Optional WAF WebACL ARN to attach to this CloudFront distribution."
 }
+
+variable "response_headers_policy_id" {
+  type        = string
+  nullable    = true
+  default     = null
+  description = "Optional CloudFront Distribution Response Header ID to attach to this CloudFront distribution."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -377,6 +377,13 @@ variable "web_acl_id" {
   description = "Optional WAF WebACL ARN to attach to this CloudFront distribution."
 }
 
+variable "response_headers_policy_id" {
+  type        = string
+  nullable    = true
+  default     = null
+  description = "Optional CloudFront Distribution Response Header ID to attach to this CloudFront distribution."
+}
+
 variable "enable_cf_logs" {
   type        = bool
   description = "Select to enable storing CloudFront logs in s3 bucket."


### PR DESCRIPTION
- Introduces `response_headers_policy_id` (nullable string) for linking an
  existing CloudFront Response Headers Policy
- Wired into `aws_cloudfront_distribution` s3 static website behavior via
  `response_headers_policy_id`; omitted when null (no plan diff by default).
