### PR TITLE
feat: add CloudFront V2 logging support with S3 and CloudWatch destination

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -295,9 +295,10 @@ module "cloudfront_cdn" {
   calculated_zone_id           = var.enable_custom_domain ? module.dns_and_certificates[0].hosted_zone_id : ""
   create_route53_domain_record = var.enable_custom_domain
 
-  enable_cf_logs        = var.enable_cf_logs
-  cf_logs_expiration    = var.cf_logs_expiration
-  cf_origin_access_mode = var.cf_origin_access_mode
+  enable_cf_logs         = var.enable_cf_logs
+  cf_logs_expiration     = var.cf_logs_expiration
+  cf_logs_v2_destination = var.cf_logs_v2_destination
+  cf_origin_access_mode  = var.cf_origin_access_mode
 
   enable_s3_for_static_website                                   = var.enable_s3_for_static_website
   s3_static_website_bucket_cf_function_arn                       = var.s3_static_website_bucket_cf_function_arn

--- a/modules/cloudfront_cdn/provider.tf
+++ b/modules/cloudfront_cdn/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  alias  = "use1"
+  region = "us-east-1"
+}

--- a/modules/cloudfront_cdn/variables.tf
+++ b/modules/cloudfront_cdn/variables.tf
@@ -148,6 +148,16 @@ variable "cf_logs_expiration" {
   default     = 90
 }
 
+variable "cf_logs_v2_destination" {
+  description = "Where CloudFront v2 should deliver logs. Allowed values: \"none\" or \"s3\" or \"cloudwatch\"."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "s3", "cloudwatch"], var.cf_logs_v2_destination)
+    error_message = "cf_v2_logging_destination must be either \"none\" or \"s3\" or \"cloudwatch\"."
+  }
+}
 variable "cf_web_acl_id" {
   type        = string
   nullable    = true

--- a/variables.tf
+++ b/variables.tf
@@ -407,6 +407,17 @@ variable "cf_logs_expiration" {
   default     = 90
 }
 
+variable "cf_logs_v2_destination" {
+  description = "Where CloudFront v2 should deliver logs. Allowed values: \"none\" or \"s3\" or \"cloudwatch\"."
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "s3", "cloudwatch"], var.cf_logs_v2_destination)
+    error_message = "cf_v2_logging_destination must be either \"none\" or \"s3\" or \"cloudwatch\"."
+  }
+}
+
 variable "disable_custom_error_response" {
   type        = bool
   default     = false


### PR DESCRIPTION
- Added CloudFront V2 logging support.
- Introduced new parameter **cf_logs_v2_destination** to define the logging destination.
- Supported destination options: **s3** and **cloudwatch**.
- Implemented conditional creation of logging resources based on selected destination.
- Enabled delivery of enhanced access logs to either S3 bucket or CloudWatch Logs.