### PR TITLE
feat: update Lambda runtime to nodejs24.x and ugrade AWS provider to 6.42.0

### DIFF
--- a/examples/example_1/versions.tf
+++ b/examples/example_1/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.0.0, < 6.0.0"
+      version = ">=5.0.0, >= 6.42.0"
     }
     cloud-init = {
       source  = "hashicorp/cloudinit"

--- a/examples/example_2/versions.tf
+++ b/examples/example_2/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.0.0, < 6.0.0"
+      version = ">=5.0.0, >= 6.42.0"
     }
     cloud-init = {
       source  = "hashicorp/cloudinit"

--- a/examples/example_3/versions.tf
+++ b/examples/example_3/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.0.0, < 6.0.0"
+      version = ">=5.0.0, >= 6.42.0"
     }
     cloud-init = {
       source  = "hashicorp/cloudinit"

--- a/modules/account/main.tf
+++ b/modules/account/main.tf
@@ -23,6 +23,6 @@ resource "aws_ebs_snapshot_block_public_access" "block_public_access" {
 resource "aws_ssm_service_setting" "ssm_document_block_public_sharing" {
   count = var.enable_account_wide_ssm_document_block_public_sharing ? 1 : 0
 
-  setting_id    = "arn:aws:ssm:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:servicesetting/ssm/documents/console/public-sharing-permission"
+  setting_id    = "arn:aws:ssm:${data.aws_region.current_region.id}:${data.aws_caller_identity.current.account_id}:servicesetting/ssm/documents/console/public-sharing-permission"
   setting_value = "Disable"
 }

--- a/modules/app_component/locals.tf
+++ b/modules/app_component/locals.tf
@@ -59,7 +59,7 @@ locals {
       "logDriver" : "awslogs",
       "options" : {
         awslogs-group : "${var.name}LogGroup",
-        awslogs-region : data.aws_region.current_region.name,
+        awslogs-region : data.aws_region.current_region.id,
         awslogs-stream-prefix : var.solution_name
       }
     }
@@ -94,7 +94,7 @@ locals {
       "logDriver" : "awslogs",
       "options" : {
         awslogs-group : "${var.name}LogGroup",
-        awslogs-region : data.aws_region.current_region.name,
+        awslogs-region : data.aws_region.current_region.id,
         awslogs-stream-prefix : var.solution_name
       }
     }

--- a/modules/app_component/main.tf
+++ b/modules/app_component/main.tf
@@ -589,7 +589,7 @@ data "aws_iam_policy_document" "ssm_parameter_cloudfront_private_key" {
   statement {
     sid       = "cfPrivatekeyAccessPermissions"
     effect    = "Allow"
-    resources = ["arn:aws:ssm:${data.aws_region.current_region.name}:${data.aws_caller_identity.this.account_id}:parameter/${var.solution_name}/cloudfront/*"]
+    resources = ["arn:aws:ssm:${data.aws_region.current_region.id}:${data.aws_caller_identity.this.account_id}:parameter/${var.solution_name}/cloudfront/*"]
     actions = [
       "ssm:GetParameters"
     ]

--- a/modules/app_component/main.tf
+++ b/modules/app_component/main.tf
@@ -1195,7 +1195,5 @@ resource "aws_service_discovery_service" "this" {
     routing_policy = "MULTIVALUE"
   }
 
-  health_check_custom_config {
-    failure_threshold = 1
-  }
+  health_check_custom_config {}
 }

--- a/modules/app_components/versions.tf
+++ b/modules/app_components/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.0.0, < 6.0.0"
+      version = ">=5.0.0, <= 6.42.0"
     }
   }
 }

--- a/modules/container/versions.tf
+++ b/modules/container/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.0.0, < 6.0.0"
+      version = ">=5.0.0, <= 6.42.0"
     }
   }
 }

--- a/modules/dns_and_certificates/versions.tf
+++ b/modules/dns_and_certificates/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">=5.0.0, < 6.0.0"
+      version               = ">=5.0.0, <= 6.42.0"
       configuration_aliases = [aws.useast1]
     }
   }

--- a/modules/ebs_snapshot_lifecycle/iam.tf
+++ b/modules/ebs_snapshot_lifecycle/iam.tf
@@ -24,7 +24,7 @@ resource "aws_iam_policy" "lambda_ebs_snapshot" {
         Resource = "*"
         Condition = {
           StringEquals = {
-            "aws:RequestedRegion" = data.aws_region.current.name
+            "aws:RequestedRegion" = data.aws_region.current.id
           }
         }
       },
@@ -86,8 +86,8 @@ resource "aws_iam_policy" "lambda_ebs_snapshot" {
           "dynamodb:Query",
         ]
         Resource = [
-          "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.solution_name}-${var.app_component_name}-ebs-lifecycle",
-          "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${var.solution_name}-${var.app_component_name}-ebs-lifecycle/index/snapshotId-index",
+          "arn:aws:dynamodb:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:table/${var.solution_name}-${var.app_component_name}-ebs-lifecycle",
+          "arn:aws:dynamodb:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:table/${var.solution_name}-${var.app_component_name}-ebs-lifecycle/index/snapshotId-index",
         ]
       },
       {

--- a/modules/ebs_snapshot_lifecycle/iam.tf
+++ b/modules/ebs_snapshot_lifecycle/iam.tf
@@ -35,7 +35,7 @@ resource "aws_iam_policy" "lambda_ebs_snapshot" {
           "ssm:PutParameter",
           "ssm:GetParameter",
         ]
-        Resource = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${var.solution_name}/ebs_snapshot/${var.app_component_name}/*"
+        Resource = "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter/${var.solution_name}/ebs_snapshot/${var.app_component_name}/*"
       },
       {
         Sid    = "ECSService"

--- a/modules/ebs_snapshot_lifecycle/main.tf
+++ b/modules/ebs_snapshot_lifecycle/main.tf
@@ -119,7 +119,7 @@ resource "aws_cloudwatch_metric_alarm" "snapshot_failed" {
 
 module "snapshot_lambda" {
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.20.1"
+  version = "8.8.0"
 
   function_name = "${var.solution_name}-${var.app_component_name}-ebs-snap"
   description   = "Snapshots EBS volumes on ECS task stop for ${var.solution_name}/${var.app_component_name}"

--- a/modules/ec2_docker_workload/iam.tf
+++ b/modules/ec2_docker_workload/iam.tf
@@ -104,9 +104,9 @@ resource "aws_iam_role_policy" "ecr_access" {
           "ecr:GetDownloadUrlForLayer"
         ]
         Resource = local.is_ecr_image ? [
-          "arn:aws:ecr:${data.aws_region.current.name}:${var.ecr_source_account_id != "" ? var.ecr_source_account_id : data.aws_caller_identity.current.account_id}:repository/${local.ecr_repo_name}"
+          "arn:aws:ecr:${data.aws_region.current.id}:${var.ecr_source_account_id != "" ? var.ecr_source_account_id : data.aws_caller_identity.current.account_id}:repository/${local.ecr_repo_name}"
           ] : [
-          "arn:aws:ecr:${data.aws_region.current.name}:${var.ecr_source_account_id != "" ? var.ecr_source_account_id : data.aws_caller_identity.current.account_id}:repository/*"
+          "arn:aws:ecr:${data.aws_region.current.id}:${var.ecr_source_account_id != "" ? var.ecr_source_account_id : data.aws_caller_identity.current.account_id}:repository/*"
         ]
       }
     ]
@@ -139,8 +139,8 @@ resource "aws_iam_role_policy" "ebs_volume_attachment" {
           "ec2:DetachVolume"
         ]
         Resource = [
-          "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*",
-          "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:instance/*"
+          "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:volume/*",
+          "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:instance/*"
         ]
       }
     ]
@@ -202,10 +202,10 @@ resource "aws_iam_role_policy" "secrets_access" {
             "kms:Decrypt",
             "kms:DescribeKey"
           ]
-          Resource = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:key/*"
+          Resource = "arn:aws:kms:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:key/*"
           Condition = {
             StringEquals = {
-              "kms:ViaService" = "ssm.${data.aws_region.current.name}.amazonaws.com"
+              "kms:ViaService" = "ssm.${data.aws_region.current.id}.amazonaws.com"
             }
           }
         }

--- a/modules/ec2_docker_workload/main.tf
+++ b/modules/ec2_docker_workload/main.tf
@@ -240,7 +240,7 @@ resource "aws_kms_key" "logs" {
         Sid    = "Allow CloudWatch Logs"
         Effect = "Allow"
         Principal = {
-          Service = "logs.${data.aws_region.current.name}.amazonaws.com"
+          Service = "logs.${data.aws_region.current.id}.amazonaws.com"
         }
         Action = [
           "kms:Encrypt",
@@ -253,7 +253,7 @@ resource "aws_kms_key" "logs" {
         Resource = "*"
         Condition = {
           ArnLike = {
-            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
+            "kms:EncryptionContext:aws:logs:arn" = "arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:*"
           }
         }
       }
@@ -297,7 +297,7 @@ locals {
     instance_name             = var.instance_name
     log_group_name            = aws_cloudwatch_log_group.docker_logs.name
     solution_name             = var.solution_name
-    aws_region                = data.aws_region.current.name
+    aws_region                = data.aws_region.current.id
     expected_devices          = join(" ", local.volume_device_names)
     enable_ecr_access         = var.enable_ecr_access
     enable_internal_dns       = var.enable_internal_dns
@@ -572,8 +572,8 @@ resource "aws_iam_role_policy" "backup_ebs_policy" {
           "ec2:CreateTags"
         ]
         Resource = concat(
-          [for vol in var.ebs_volumes : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"],
-          ["arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot/*"]
+          [for vol in var.ebs_volumes : "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:volume/*"],
+          ["arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:snapshot/*"]
         )
       },
       {
@@ -583,8 +583,8 @@ resource "aws_iam_role_policy" "backup_ebs_policy" {
           "ec2:DescribeInstances"
         ]
         Resource = [
-          "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:instance/*",
-          "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*"
+          "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:instance/*",
+          "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:volume/*"
         ]
       },
       {

--- a/modules/fck_nat_instances/main.tf
+++ b/modules/fck_nat_instances/main.tf
@@ -257,7 +257,7 @@ resource "aws_iam_role_policy_attachment" "main" {
 }
 
 locals {
-  fck_nat_eip_allocation_ids = [for eip in aws_eip.main : "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:elastic-ip/${eip.id}"]
+  fck_nat_eip_allocation_ids = [for eip in aws_eip.main : "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:elastic-ip/${eip.id}"]
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards
@@ -305,7 +305,7 @@ data "aws_iam_policy_document" "main" {
         "ec2:DisassociateAddress",
       ]
       resources = [
-        "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:network-interface/*"
+        "arn:aws:ec2:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:network-interface/*"
       ]
       condition {
         test     = "StringLike"

--- a/modules/global_scale_down/iam.tf
+++ b/modules/global_scale_down/iam.tf
@@ -1,6 +1,6 @@
 locals {
   asg_arn   = concat(var.ecs_ec2_instances_autoscaling_group_arn, var.nat_instances_autoscaling_group_arn, var.fck_nat_instances_autoscaling_group_arn, var.bastion_host_autoscaling_group_arn)
-  redis_arn = concat(var.redis_cluster_arn, var.redis_subnet_group_arn, [var.redis_security_group_arn], ["arn:aws:elasticache:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parametergroup:*"])
+  redis_arn = concat(var.redis_cluster_arn, var.redis_subnet_group_arn, [var.redis_security_group_arn], ["arn:aws:elasticache:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parametergroup:*"])
 }
 
 resource "aws_iam_policy" "scale_up_down_asg_policy" {
@@ -82,10 +82,10 @@ resource "aws_iam_policy" "scale_up_down_iam_policy" {
             "ssm:GetParameter"
           ],
           "Resource" : [
-            "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.ecs_service_data}",
-            "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.scale_up_parameters}",
-            "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.hibernation_state}",
-            "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.token}"
+            "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter${local.ecs_service_data}",
+            "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter${local.scale_up_parameters}",
+            "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter${local.hibernation_state}",
+            "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter${local.token}"
           ]
         },
         {
@@ -95,8 +95,8 @@ resource "aws_iam_policy" "scale_up_down_iam_policy" {
             "ssm:PutParameter"
           ],
           "Resource" : [
-            "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.ecs_service_data}",
-            "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.hibernation_state}"
+            "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter${local.ecs_service_data}",
+            "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter${local.hibernation_state}"
           ]
         }
       ]
@@ -120,7 +120,7 @@ resource "aws_iam_policy" "status_lambda_get_parameter" {
             "ssm:GetParameter"
           ],
           "Resource" : [
-            "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${local.hibernation_state}",
+            "arn:aws:ssm:${data.aws_region.current.id}:${data.aws_caller_identity.current.account_id}:parameter${local.hibernation_state}",
           ]
         }
       ]

--- a/modules/global_scale_down/main.tf
+++ b/modules/global_scale_down/main.tf
@@ -42,7 +42,7 @@ module "lambda_scale_up" {
   function_name = "${var.solution_name}-global-scale-up"
   description   = "Performs global scale up"
   handler       = "scale_up.handler"
-  runtime       = "nodejs24.x"
+  runtime       = "nodejs22.x"
   source_path   = "${path.module}/scale_up.mjs"
   timeout       = 900
 
@@ -142,7 +142,7 @@ module "lambda_scale_down" {
   function_name = "${var.solution_name}-global-scale-down"
   description   = "Performs global scale down"
   handler       = "scale_down.handler"
-  runtime       = "nodejs24.x"
+  runtime       = "nodejs22.x"
   source_path   = "${path.module}/scale_down.mjs"
   timeout       = 900
 
@@ -233,7 +233,7 @@ module "global_scale_status" {
   function_name = "${var.solution_name}-global-scale-status"
   description   = "Shows the current status of deployment."
   handler       = "status.handler"
-  runtime       = "nodejs24.x"
+  runtime       = "nodejs22.x"
   source_path   = "${path.module}/status.mjs"
   timeout       = 900
 

--- a/modules/global_scale_down/main.tf
+++ b/modules/global_scale_down/main.tf
@@ -42,7 +42,7 @@ module "lambda_scale_up" {
   function_name = "${var.solution_name}-global-scale-up"
   description   = "Performs global scale up"
   handler       = "scale_up.handler"
-  runtime       = "nodejs22.x"
+  runtime       = "nodejs24.x"
   source_path   = "${path.module}/scale_up.mjs"
   timeout       = 900
 
@@ -142,7 +142,7 @@ module "lambda_scale_down" {
   function_name = "${var.solution_name}-global-scale-down"
   description   = "Performs global scale down"
   handler       = "scale_down.handler"
-  runtime       = "nodejs22.x"
+  runtime       = "nodejs24.x"
   source_path   = "${path.module}/scale_down.mjs"
   timeout       = 900
 
@@ -233,7 +233,7 @@ module "global_scale_status" {
   function_name = "${var.solution_name}-global-scale-status"
   description   = "Shows the current status of deployment."
   handler       = "status.handler"
-  runtime       = "nodejs22.x"
+  runtime       = "nodejs24.x"
   source_path   = "${path.module}/status.mjs"
   timeout       = 900
 

--- a/modules/global_scale_down/main.tf
+++ b/modules/global_scale_down/main.tf
@@ -37,7 +37,7 @@ module "lambda_scale_up" {
   count = var.enable_environment_hibernation_sleep_schedule ? 1 : 0
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.20.1"
+  version = "8.8.0"
 
   function_name = "${var.solution_name}-global-scale-up"
   description   = "Performs global scale up"
@@ -104,7 +104,7 @@ resource "aws_lambda_permission" "scale_up_lambda_invoke_function_permission" {
 module "eventbridge_up" {
   count   = var.enable_environment_hibernation_sleep_schedule ? 1 : 0
   source  = "terraform-aws-modules/eventbridge/aws"
-  version = "3.14.3"
+  version = "4.3.0"
 
   bus_name = "${var.solution_name}-scale-up" # "default" bus already support schedule_expression in rules
 
@@ -137,7 +137,7 @@ module "lambda_scale_down" {
   count = var.enable_environment_hibernation_sleep_schedule ? 1 : 0
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.20.1"
+  version = "8.8.0"
 
   function_name = "${var.solution_name}-global-scale-down"
   description   = "Performs global scale down"
@@ -204,7 +204,7 @@ resource "aws_lambda_permission" "scale_down_lambda_invoke_function_permission" 
 module "eventbridge_down" {
   count   = var.enable_environment_hibernation_sleep_schedule ? 1 : 0
   source  = "terraform-aws-modules/eventbridge/aws"
-  version = "3.14.3"
+  version = "4.3.0"
 
   bus_name = "${var.solution_name}-scale-down" # "default" bus already support schedule_expression in rules
 
@@ -228,7 +228,7 @@ module "global_scale_status" {
   count = var.enable_environment_hibernation_sleep_schedule ? 1 : 0
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.20.1"
+  version = "8.8.0"
 
   function_name = "${var.solution_name}-global-scale-status"
   description   = "Shows the current status of deployment."

--- a/modules/lambda_at_edge/main.tf
+++ b/modules/lambda_at_edge/main.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "lambda_at_edge" {
   role    = aws_iam_role.iam_for_lambda_at_edge.arn
   handler = "${var.file_name}.handler"
   publish = true
-  runtime = "nodejs20.x"
+  runtime = "nodejs24.x"
 
   source_code_hash = data.archive_file.lambda_at_edge.output_base64sha256
 

--- a/modules/lambda_at_edge/main.tf
+++ b/modules/lambda_at_edge/main.tf
@@ -19,7 +19,7 @@ resource "aws_lambda_function" "lambda_at_edge" {
   role    = aws_iam_role.iam_for_lambda_at_edge.arn
   handler = "${var.file_name}.handler"
   publish = true
-  runtime = "nodejs24.x"
+  runtime = "nodejs20.x"
 
   source_code_hash = data.archive_file.lambda_at_edge.output_base64sha256
 

--- a/modules/lambda_at_edge/versions.tf
+++ b/modules/lambda_at_edge/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source                = "hashicorp/aws"
-      version               = ">=5.0.0, < 6.0.0"
+      version               = ">=5.0.0, <= 6.42.0"
       configuration_aliases = [aws.useast1]
     }
   }

--- a/modules/loadbalancer/main.tf
+++ b/modules/loadbalancer/main.tf
@@ -86,7 +86,7 @@ module "log_bucket" {
   count = var.enable_alb_logs ? 1 : 0
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "4.6.0"
+  version = "5.12.0"
 
   bucket = "${var.solution_name}-alb-logs-s3-bucket-${random_string.random_s3_alb_logs_postfix.result}"
   acl    = "log-delivery-write"

--- a/modules/oidc_role/main.tf
+++ b/modules/oidc_role/main.tf
@@ -167,7 +167,7 @@ resource "aws_iam_policy" "ecr_deployment_policy" {
             "ecr:BatchGetImage",
             "ecr:GetDownloadUrlForLayer"
           ],
-          "Resource" : "arn:aws:ecr:${data.aws_region.current_region.name}:${data.aws_caller_identity.current.account_id}:repository/${each.value.ecr_name}"
+          "Resource" : "arn:aws:ecr:${data.aws_region.current_region.id}:${data.aws_caller_identity.current.account_id}:repository/${each.value.ecr_name}"
         },
         {
           "Sid" : "ECRRetrieveCredentials",

--- a/modules/scheduled_api_call/main.tf
+++ b/modules/scheduled_api_call/main.tf
@@ -37,7 +37,7 @@ module "lambda" {
   function_name = "${var.solution_name}-scheduled-https-api-call"
   description   = "scheduled https api call"
   handler       = "api_call.handler"
-  runtime       = "nodejs24.x"
+  runtime       = "nodejs20.x"
   source_path   = "${path.module}/api_call.js"
 
   create_current_version_allowed_triggers = false

--- a/modules/scheduled_api_call/main.tf
+++ b/modules/scheduled_api_call/main.tf
@@ -37,7 +37,7 @@ module "lambda" {
   function_name = "${var.solution_name}-scheduled-https-api-call"
   description   = "scheduled https api call"
   handler       = "api_call.handler"
-  runtime       = "nodejs20.x"
+  runtime       = "nodejs24.x"
   source_path   = "${path.module}/api_call.js"
 
   create_current_version_allowed_triggers = false

--- a/modules/scheduled_api_call/main.tf
+++ b/modules/scheduled_api_call/main.tf
@@ -5,7 +5,7 @@ module "eventbridge" {
   count = var.enable_scheduled_https_api_call ? 1 : 0
 
   source  = "terraform-aws-modules/eventbridge/aws"
-  version = "3.2.3"
+  version = "4.3.0"
 
   create_bus = false
 
@@ -32,7 +32,7 @@ module "lambda" {
   count = var.enable_scheduled_https_api_call ? 1 : 0
 
   source  = "terraform-aws-modules/lambda/aws"
-  version = "7.2.3"
+  version = "8.8.0"
 
   function_name = "${var.solution_name}-scheduled-https-api-call"
   description   = "scheduled https api call"

--- a/modules/ses/main.tf
+++ b/modules/ses/main.tf
@@ -37,7 +37,7 @@ resource "aws_route53_record" "mx_send_mail_from" {
   name    = var.mail_from_domain
   type    = "MX"
   ttl     = "600"
-  records = ["10 feedback-smtp.${data.aws_region.current_region.name}.amazonses.com"]
+  records = ["10 feedback-smtp.${data.aws_region.current_region.id}.amazonses.com"]
 }
 
 # Receiving MX Record
@@ -47,7 +47,7 @@ resource "aws_route53_record" "mx_receive" {
   zone_id = data.aws_route53_zone.main.zone_id
   type    = "MX"
   ttl     = "600"
-  records = ["10 inbound-smtp.${data.aws_region.current_region.name}.amazonaws.com"]
+  records = ["10 inbound-smtp.${data.aws_region.current_region.id}.amazonaws.com"]
 }
 
 # SES DKIM Verification
@@ -123,12 +123,12 @@ data "aws_iam_policy_document" "send_mail" {
 locals {
   initial_value = jsonencode({
     AWS_SES_SOURCE_ARN = aws_ses_domain_identity.ses_domain[*].arn
-    SMTP_ADDRESS       = "email-smtp.${data.aws_region.current_region.name}.amazonaws.com"
+    SMTP_ADDRESS       = "email-smtp.${data.aws_region.current_region.id}.amazonaws.com"
     SMTP_AUTH          = "plain"
     SMTP_DOMAIN        = var.ses_domain_name
     SMTP_PASSWORD      = aws_iam_access_key.smtp_user[*].ses_smtp_password_v4
     SMTP_PORT          = 2587
-    SMTP_REGION        = data.aws_region.current_region.name
+    SMTP_REGION        = data.aws_region.current_region.id
     SMTP_SECRET        = aws_iam_access_key.smtp_user[*].secret
     SMTP_USERNAME      = aws_iam_access_key.smtp_user[*].id
   })

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.0.0, < 6.0.0"
+      version = ">=5.0.0, <= 6.42.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Upgrade AWS provider to 6.42.0 to support the nodejs24.x runtime and update Lambda functions in global_scale_down, lambda_at_edge and scheduled_api_call modules to use it.