### PR TITLE
AMI update automation

### DIFF
--- a/examples/ec2_docker_workload/main.tf
+++ b/examples/ec2_docker_workload/main.tf
@@ -43,8 +43,9 @@ module "terra3_examples" {
   create_database = false
   nat             = "NAT_INSTANCES" # Required for container image pulls
 
-  create_bastion_host = true
-  enable_ecs_exec     = true # Required for app_components with enable_ecs_exec
+  create_bastion_host        = true
+  enable_bastion_ami_updates = true
+  enable_ecs_exec            = true # Required for app_components with enable_ecs_exec
 
   enable_internal_service_dns = true
 
@@ -223,6 +224,9 @@ module "postgres_docker" {
   backup_retention_days = 7
   backup_schedule       = "cron(30 14 ? * * *)" # Daily at 14:30 UTC (testing)
 
+  # AMI Update Automation
+  enable_ami_updates = true
+
   # Internal DNS is enabled by default
   # The Route53 zone is created by the Terra3 base module
   # This module automatically creates DNS A records for service discovery
@@ -256,51 +260,15 @@ module "nginx_docker" {
   # CloudWatch Logs
   log_retention_days = 30
 
+  # AMI Update Automation
+  enable_ami_updates = true
+
   # Explicit dependencies to ensure proper deployment order and SSM access
   # Note: nginx depends on postgres being fully deployed to avoid race conditions
   # with security group and Route53 zone initialization
   depends_on = [
     module.terra3_examples
   ]
-}
-
-# -----------------------------------------------
-# AMI Update Automation
-# -----------------------------------------------
-# Periodically checks for newer Amazon Linux 2023 AMIs and triggers
-# a rolling instance refresh to keep workloads patched.
-
-module "postgres_ami_update" {
-  source = "../../modules/ami_update_automation"
-
-  solution_name      = local.solution_name
-  name_suffix        = "postgres"
-  launch_template_id = module.postgres_docker.launch_template_id
-  asg_name           = module.postgres_docker.asg_name
-
-  depends_on = [module.postgres_docker]
-}
-
-module "nginx_ami_update" {
-  source = "../../modules/ami_update_automation"
-
-  solution_name      = local.solution_name
-  name_suffix        = "nginx"
-  launch_template_id = module.nginx_docker.launch_template_id
-  asg_name           = module.nginx_docker.asg_name
-
-  depends_on = [module.nginx_docker]
-}
-
-module "bastion_ami_update" {
-  source = "../../modules/ami_update_automation"
-
-  solution_name      = local.solution_name
-  name_suffix        = "bastion"
-  launch_template_id = module.terra3_examples.bastion_host_launch_template_id
-  asg_name           = module.terra3_examples.bastion_host_asg_name
-
-  depends_on = [module.terra3_examples]
 }
 
 # -----------------------------------------------

--- a/examples/ec2_docker_workload/main.tf
+++ b/examples/ec2_docker_workload/main.tf
@@ -14,7 +14,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">=5.0.0, < 6.0.0"
+      version = ">=5.0.0, <= 6.42.0"
     }
   }
 }
@@ -213,15 +213,15 @@ module "postgres_docker" {
   ]
 
   # Required: Explicitly specify AZ for EBS volumes to prevent replacement on re-apply
-  ebs_volume_availability_zone = "<tbd>"
+  ebs_volume_availability_zone = "eu-central-1b"
 
   # CloudWatch Logs
-  log_retention_days = 7
+  log_retention_days = 30
 
   # Backup Configuration
   enable_backup         = true
   backup_retention_days = 7
-  backup_schedule       = "cron(0 2 ? * * *)" # Daily at 2 AM UTC
+  backup_schedule       = "cron(30 14 ? * * *)" # Daily at 14:30 UTC (testing)
 
   # Internal DNS is enabled by default
   # The Route53 zone is created by the Terra3 base module
@@ -254,15 +254,42 @@ module "nginx_docker" {
   ]
 
   # CloudWatch Logs
-  log_retention_days = 7
+  log_retention_days = 30
 
   # Explicit dependencies to ensure proper deployment order and SSM access
   # Note: nginx depends on postgres being fully deployed to avoid race conditions
   # with security group and Route53 zone initialization
   depends_on = [
-    module.terra3_examples,
-    module.postgres_docker
+    module.terra3_examples
   ]
+}
+
+# -----------------------------------------------
+# AMI Update Automation
+# -----------------------------------------------
+# Periodically checks for newer Amazon Linux 2023 AMIs and triggers
+# a rolling instance refresh to keep workloads patched.
+
+module "postgres_ami_update" {
+  source = "../../modules/ami_update_automation"
+
+  solution_name      = local.solution_name
+  name_suffix        = "postgres"
+  launch_template_id = module.postgres_docker.launch_template_id
+  asg_name           = module.postgres_docker.asg_name
+
+  depends_on = [module.postgres_docker]
+}
+
+module "nginx_ami_update" {
+  source = "../../modules/ami_update_automation"
+
+  solution_name      = local.solution_name
+  name_suffix        = "nginx"
+  launch_template_id = module.nginx_docker.launch_template_id
+  asg_name           = module.nginx_docker.asg_name
+
+  depends_on = [module.nginx_docker]
 }
 
 # -----------------------------------------------

--- a/examples/ec2_docker_workload/main.tf
+++ b/examples/ec2_docker_workload/main.tf
@@ -292,6 +292,17 @@ module "nginx_ami_update" {
   depends_on = [module.nginx_docker]
 }
 
+module "bastion_ami_update" {
+  source = "../../modules/ami_update_automation"
+
+  solution_name      = local.solution_name
+  name_suffix        = "bastion"
+  launch_template_id = module.terra3_examples.bastion_host_launch_template_id
+  asg_name           = module.terra3_examples.bastion_host_asg_name
+
+  depends_on = [module.terra3_examples]
+}
+
 # -----------------------------------------------
 # Grant ECS Task Role Access to SSM Parameter Store
 # -----------------------------------------------

--- a/examples/ec2_docker_workload/main.tf
+++ b/examples/ec2_docker_workload/main.tf
@@ -214,7 +214,7 @@ module "postgres_docker" {
   ]
 
   # Required: Explicitly specify AZ for EBS volumes to prevent replacement on re-apply
-  ebs_volume_availability_zone = "eu-central-1b"
+  ebs_volume_availability_zone = "<tbd>"
 
   # CloudWatch Logs
   log_retention_days = 30

--- a/main.tf
+++ b/main.tf
@@ -453,6 +453,8 @@ module "bastion_host_ssm" {
   vpc_id           = local.vpc_id
   private_subnets  = local.private_subnets
 
+  enable_ami_updates = var.enable_bastion_ami_updates
+
   depends_on = [module.security_groups]
 }
 

--- a/modules/ami_update_automation/README.md
+++ b/modules/ami_update_automation/README.md
@@ -1,0 +1,116 @@
+# AMI Update Automation Module
+
+Periodically checks for newer AMIs, updates the launch template, and triggers an ASG instance refresh to keep EC2 workloads patched automatically.
+
+## How It Works
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                    AMI Update Automation Process                         │
+└─────────────────────────────────────────────────────────────────────────┘
+
+ ┌──────────────┐         ┌──────────────────┐
+ │  EventBridge │ rate(7d)│   Lambda          │
+ │  Schedule    │────────▶│   ami_updater.mjs │
+ └──────────────┘         └────────┬─────────┘
+                                   │
+                    ┌──────────────┼──────────────────────────────┐
+                    │              ▼                               │
+                    │  ┌─────────────────────┐                    │
+                    │  │ 1. DescribeImages    │                    │
+                    │  │    (filter: al2023,  │                    │
+                    │  │     arm64, gp3)      │                    │
+                    │  └──────────┬──────────┘                    │
+                    │             ▼                                │
+                    │  ┌─────────────────────────────┐            │
+                    │  │ 2. DescribeLaunchTemplate    │            │
+                    │  │    Versions ($Latest)        │            │
+                    │  └──────────┬──────────────────┘            │
+                    │             ▼                                │
+                    │  ┌─────────────────────┐                    │
+                    │  │ 3. Compare AMI IDs  │                    │
+                    │  └──────┬─────────┬────┘                    │
+                    │         │         │                          │
+                    │    Same │         │ Different                │
+                    │         ▼         ▼                          │
+                    │  ┌──────────┐  ┌──────────────────────┐     │
+                    │  │ EXIT     │  │ 4. Check active       │     │
+                    │  │ (no-op)  │  │    instance refresh   │     │
+                    │  └──────────┘  └──────────┬───────────┘     │
+                    │                           │                  │
+                    │                  Active?  │  None?           │
+                    │                    │      │                  │
+                    │                    ▼      ▼                  │
+                    │  ┌──────────┐  ┌──────────────────────────┐ │
+                    │  │ EXIT     │  │ 5. CreateLaunchTemplate   │ │
+                    │  │ (skip)   │  │    Version (new AMI)      │ │
+                    │  └──────────┘  └──────────┬───────────────┘ │
+                    │                           ▼                  │
+                    │                ┌─────────────────────────┐   │
+                    │                │ 6. StartInstanceRefresh  │   │
+                    │                │    (Rolling, 0% healthy) │   │
+                    │                └──────────┬──────────────┘   │
+                    │                           ▼                  │
+                    │                ┌─────────────────────────┐   │
+                    │                │ 7. SNS Notification      │   │
+                    │                │    (optional)            │   │
+                    │                └─────────────────────────┘   │
+                    │                                              │
+                    └──────────────────────────────────────────────┘
+                                        │
+                                        ▼
+┌─────────────────────────────────────────────────────────────────────────┐
+│                     ASG Instance Refresh (AWS-managed)                   │
+│                                                                         │
+│  1. Terminate old instance (running stale AMI)                          │
+│  2. Launch new instance from updated launch template (new AMI)          │
+│  3. Wait for health check (instance_warmup: 300s)                       │
+│  4. Mark refresh Successful (or rollback if unhealthy)                  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The Lambda only triggers the update. The actual instance replacement is handled by AWS Auto Scaling's native instance refresh mechanism, which includes automatic rollback if the new instance fails health checks.
+
+## Usage
+
+```hcl
+module "bastion_ami_update" {
+  source = "./modules/ami_update_automation"
+
+  solution_name      = var.solution_name
+  name_suffix        = "bastion"
+  launch_template_id = module.bastion_host_ssm[0].launch_template_id
+  asg_name           = module.bastion_host_ssm[0].bastion_host_autoscaling_group_name
+}
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `solution_name` | - | Resource naming prefix |
+| `name_suffix` | - | Unique suffix per instance (e.g., "bastion", "postgres") |
+| `launch_template_id` | - | Target launch template ID |
+| `asg_name` | - | Target Auto Scaling Group name |
+| `ami_owners` | `["amazon"]` | AMI owner accounts |
+| `ami_name_filter` | `"al2023-ami-2023*"` | AMI name pattern |
+| `ami_architecture` | `"arm64"` | CPU architecture |
+| `schedule_expression` | `"rate(7 days)"` | Check frequency |
+| `min_healthy_percentage` | `0` | Min healthy % during refresh (0 for single-instance ASGs) |
+| `instance_warmup_seconds` | `300` | Warmup period for new instance |
+| `sns_topic_arn` | `""` | Optional SNS topic for notifications |
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No newer AMI | Lambda exits early, no action |
+| Refresh already in progress | Lambda skips, next scheduled run retries |
+| New instance unhealthy | ASG rolls back automatically |
+| Lambda timeout mid-operation | Next run detects AMI mismatch, retries safely |
+
+## Manual Invocation
+
+```bash
+aws lambda invoke --function-name <solution>-ami-update-<suffix> --region <region> /dev/stdout
+```

--- a/modules/ami_update_automation/ami_updater.mjs
+++ b/modules/ami_update_automation/ami_updater.mjs
@@ -32,9 +32,37 @@ export const handler = async () => {
   const additionalFilters = JSON.parse(AMI_ADDITIONAL_FILTERS);
 
   try {
+    const ltVersionsResp = await ec2.send(
+      new DescribeLaunchTemplateVersionsCommand({
+        LaunchTemplateId: LAUNCH_TEMPLATE_ID,
+        Versions: ["$Latest"],
+      })
+    );
+
+    const currentVersion = ltVersionsResp.LaunchTemplateVersions[0];
+    const currentAmiId = currentVersion.LaunchTemplateData.ImageId;
+
+    let architecture = AMI_ARCHITECTURE;
+    if (!architecture || architecture === "auto") {
+      const currentAmiResp = await ec2.send(
+        new DescribeImagesCommand({ ImageIds: [currentAmiId] })
+      );
+      if (currentAmiResp.Images && currentAmiResp.Images.length > 0) {
+        architecture = currentAmiResp.Images[0].Architecture;
+        console.log(
+          `Auto-detected architecture from current AMI: ${architecture}`
+        );
+      } else {
+        architecture = "arm64";
+        console.log(
+          `Could not describe current AMI ${currentAmiId}, falling back to arm64`
+        );
+      }
+    }
+
     const filters = [
       { Name: "name", Values: [AMI_NAME_FILTER] },
-      { Name: "architecture", Values: [AMI_ARCHITECTURE] },
+      { Name: "architecture", Values: [architecture] },
       { Name: "state", Values: ["available"] },
     ];
 
@@ -58,16 +86,6 @@ export const handler = async () => {
     console.log(
       `Latest AMI: ${latestAmi.ImageId} (${latestAmi.Name}), created ${latestAmi.CreationDate}`
     );
-
-    const ltVersionsResp = await ec2.send(
-      new DescribeLaunchTemplateVersionsCommand({
-        LaunchTemplateId: LAUNCH_TEMPLATE_ID,
-        Versions: ["$Latest"],
-      })
-    );
-
-    const currentVersion = ltVersionsResp.LaunchTemplateVersions[0];
-    const currentAmiId = currentVersion.LaunchTemplateData.ImageId;
     console.log(
       `Current launch template AMI: ${currentAmiId} (version ${currentVersion.VersionNumber})`
     );

--- a/modules/ami_update_automation/ami_updater.mjs
+++ b/modules/ami_update_automation/ami_updater.mjs
@@ -1,0 +1,183 @@
+import {
+  EC2Client,
+  DescribeImagesCommand,
+  DescribeLaunchTemplateVersionsCommand,
+  CreateLaunchTemplateVersionCommand,
+} from "@aws-sdk/client-ec2";
+import {
+  AutoScalingClient,
+  StartInstanceRefreshCommand,
+  DescribeInstanceRefreshesCommand,
+} from "@aws-sdk/client-auto-scaling";
+import { SNSClient, PublishCommand } from "@aws-sdk/client-sns";
+
+const ec2 = new EC2Client();
+const autoscaling = new AutoScalingClient();
+const sns = new SNSClient();
+
+export const handler = async () => {
+  const {
+    LAUNCH_TEMPLATE_ID,
+    ASG_NAME,
+    AMI_OWNERS,
+    AMI_NAME_FILTER,
+    AMI_ARCHITECTURE,
+    AMI_ADDITIONAL_FILTERS,
+    MIN_HEALTHY_PERCENTAGE,
+    INSTANCE_WARMUP,
+    SNS_TOPIC_ARN,
+  } = process.env;
+
+  const owners = JSON.parse(AMI_OWNERS);
+  const additionalFilters = JSON.parse(AMI_ADDITIONAL_FILTERS);
+
+  try {
+    const filters = [
+      { Name: "name", Values: [AMI_NAME_FILTER] },
+      { Name: "architecture", Values: [AMI_ARCHITECTURE] },
+      { Name: "state", Values: ["available"] },
+    ];
+
+    for (const [name, values] of Object.entries(additionalFilters)) {
+      filters.push({ Name: name, Values: values });
+    }
+
+    const describeImagesResp = await ec2.send(
+      new DescribeImagesCommand({ Owners: owners, Filters: filters })
+    );
+
+    if (!describeImagesResp.Images || describeImagesResp.Images.length === 0) {
+      console.log("No AMIs found matching filters. Exiting.");
+      return { statusCode: 200, body: "No matching AMIs found" };
+    }
+
+    const sortedImages = describeImagesResp.Images.sort(
+      (a, b) => new Date(b.CreationDate) - new Date(a.CreationDate)
+    );
+    const latestAmi = sortedImages[0];
+    console.log(
+      `Latest AMI: ${latestAmi.ImageId} (${latestAmi.Name}), created ${latestAmi.CreationDate}`
+    );
+
+    const ltVersionsResp = await ec2.send(
+      new DescribeLaunchTemplateVersionsCommand({
+        LaunchTemplateId: LAUNCH_TEMPLATE_ID,
+        Versions: ["$Latest"],
+      })
+    );
+
+    const currentVersion = ltVersionsResp.LaunchTemplateVersions[0];
+    const currentAmiId = currentVersion.LaunchTemplateData.ImageId;
+    console.log(
+      `Current launch template AMI: ${currentAmiId} (version ${currentVersion.VersionNumber})`
+    );
+
+    if (currentAmiId === latestAmi.ImageId) {
+      console.log("AMI is already up to date. No action needed.");
+      return { statusCode: 200, body: "AMI already up to date" };
+    }
+
+    const refreshesResp = await autoscaling.send(
+      new DescribeInstanceRefreshesCommand({
+        AutoScalingGroupName: ASG_NAME,
+        MaxRecords: 1,
+      })
+    );
+
+    const activeRefresh = refreshesResp.InstanceRefreshes?.find((r) =>
+      ["Pending", "InProgress", "Cancelling"].includes(r.Status)
+    );
+
+    if (activeRefresh) {
+      console.log(
+        `Instance refresh already in progress (${activeRefresh.InstanceRefreshId}, status: ${activeRefresh.Status}). Skipping.`
+      );
+      return {
+        statusCode: 409,
+        body: `Instance refresh already in progress: ${activeRefresh.InstanceRefreshId}`,
+      };
+    }
+
+    const createVersionResp = await ec2.send(
+      new CreateLaunchTemplateVersionCommand({
+        LaunchTemplateId: LAUNCH_TEMPLATE_ID,
+        SourceVersion: String(currentVersion.VersionNumber),
+        LaunchTemplateData: {
+          ImageId: latestAmi.ImageId,
+        },
+        VersionDescription: `AMI update: ${currentAmiId} -> ${latestAmi.ImageId} (${latestAmi.Name})`,
+      })
+    );
+
+    const newVersionNumber =
+      createVersionResp.LaunchTemplateVersion.VersionNumber;
+    console.log(
+      `Created launch template version ${newVersionNumber} with AMI ${latestAmi.ImageId}`
+    );
+
+    const refreshResp = await autoscaling.send(
+      new StartInstanceRefreshCommand({
+        AutoScalingGroupName: ASG_NAME,
+        Strategy: "Rolling",
+        Preferences: {
+          MinHealthyPercentage: parseInt(MIN_HEALTHY_PERCENTAGE, 10),
+          InstanceWarmup: parseInt(INSTANCE_WARMUP, 10),
+        },
+      })
+    );
+
+    console.log(`Started instance refresh: ${refreshResp.InstanceRefreshId}`);
+
+    if (SNS_TOPIC_ARN) {
+      await sns.send(
+        new PublishCommand({
+          TopicArn: SNS_TOPIC_ARN,
+          Subject: `[${ASG_NAME}] AMI Updated`,
+          Message: JSON.stringify(
+            {
+              asgName: ASG_NAME,
+              launchTemplateId: LAUNCH_TEMPLATE_ID,
+              previousAmi: currentAmiId,
+              newAmi: latestAmi.ImageId,
+              newAmiName: latestAmi.Name,
+              newAmiCreationDate: latestAmi.CreationDate,
+              launchTemplateVersion: newVersionNumber,
+              instanceRefreshId: refreshResp.InstanceRefreshId,
+            },
+            null,
+            2
+          ),
+        })
+      );
+      console.log("SNS notification sent.");
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        updated: true,
+        previousAmi: currentAmiId,
+        newAmi: latestAmi.ImageId,
+        instanceRefreshId: refreshResp.InstanceRefreshId,
+      }),
+    };
+  } catch (error) {
+    console.error("AMI update failed:", error);
+
+    if (SNS_TOPIC_ARN) {
+      try {
+        await sns.send(
+          new PublishCommand({
+            TopicArn: SNS_TOPIC_ARN,
+            Subject: `[${ASG_NAME}] AMI Update FAILED`,
+            Message: `Error: ${error.message}\n\nStack: ${error.stack}`,
+          })
+        );
+      } catch (snsError) {
+        console.error("Failed to send SNS failure notification:", snsError);
+      }
+    }
+
+    throw error;
+  }
+};

--- a/modules/ami_update_automation/main.tf
+++ b/modules/ami_update_automation/main.tf
@@ -26,26 +26,33 @@ resource "aws_iam_policy" "lambda_ami_updater" {
     Statement = concat(
       [
         {
-          Sid      = "DescribeAMIs"
-          Effect   = "Allow"
-          Action   = ["ec2:DescribeImages"]
+          Sid    = "DescribeEC2"
+          Effect = "Allow"
+          Action = [
+            "ec2:DescribeImages",
+            "ec2:DescribeLaunchTemplateVersions"
+          ]
           Resource = "*"
         },
         {
-          Sid    = "ManageLaunchTemplate"
+          Sid    = "UpdateLaunchTemplate"
           Effect = "Allow"
           Action = [
-            "ec2:DescribeLaunchTemplateVersions",
             "ec2:CreateLaunchTemplateVersion"
           ]
           Resource = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:launch-template/${var.launch_template_id}"
         },
         {
-          Sid    = "ManageASGRefresh"
+          Sid      = "DescribeASGRefreshes"
+          Effect   = "Allow"
+          Action   = ["autoscaling:DescribeInstanceRefreshes"]
+          Resource = "*"
+        },
+        {
+          Sid    = "StartASGRefresh"
           Effect = "Allow"
           Action = [
-            "autoscaling:StartInstanceRefresh",
-            "autoscaling:DescribeInstanceRefreshes"
+            "autoscaling:StartInstanceRefresh"
           ]
           Resource = "arn:aws:autoscaling:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:autoScalingGroup:*:autoScalingGroupName/${var.asg_name}"
         }
@@ -104,7 +111,7 @@ module "lambda" {
   allowed_triggers = {
     AmiCheckSchedule = {
       principal  = "events.amazonaws.com"
-      source_arn = module.eventbridge.eventbridge_rule_arns["ami_check"]
+      source_arn = module.eventbridge.eventbridge_rule_arns[local.function_name]
     }
   }
 
@@ -119,17 +126,19 @@ module "eventbridge" {
   source  = "terraform-aws-modules/eventbridge/aws"
   version = "4.3.0"
 
-  create_bus = false
+  create_bus                 = false
+  create_role                = false
+  create_log_delivery_source = false
 
   rules = {
-    ami_check = {
+    "${local.function_name}" = {
       description         = "Periodic AMI update check for ${var.name_suffix}"
       schedule_expression = var.schedule_expression
     }
   }
 
   targets = {
-    ami_check = [
+    "${local.function_name}" = [
       {
         name = "${local.function_name}-target"
         arn  = module.lambda.lambda_function_arn

--- a/modules/ami_update_automation/main.tf
+++ b/modules/ami_update_automation/main.tf
@@ -1,0 +1,141 @@
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  function_name = "${var.solution_name}-ami-update-${var.name_suffix}"
+  common_tags = merge(
+    var.tags,
+    {
+      Name      = local.function_name
+      ManagedBy = "Terraform"
+      Solution  = var.solution_name
+    }
+  )
+}
+
+# -----------------------------------------------------------------------------
+# IAM Policy for Lambda
+# -----------------------------------------------------------------------------
+
+resource "aws_iam_policy" "lambda_ami_updater" {
+  name        = "${local.function_name}-policy"
+  description = "Permissions for AMI update Lambda to describe images, update launch templates, and refresh ASGs"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(
+      [
+        {
+          Sid      = "DescribeAMIs"
+          Effect   = "Allow"
+          Action   = ["ec2:DescribeImages"]
+          Resource = "*"
+        },
+        {
+          Sid    = "ManageLaunchTemplate"
+          Effect = "Allow"
+          Action = [
+            "ec2:DescribeLaunchTemplateVersions",
+            "ec2:CreateLaunchTemplateVersion"
+          ]
+          Resource = "arn:aws:ec2:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:launch-template/${var.launch_template_id}"
+        },
+        {
+          Sid    = "ManageASGRefresh"
+          Effect = "Allow"
+          Action = [
+            "autoscaling:StartInstanceRefresh",
+            "autoscaling:DescribeInstanceRefreshes"
+          ]
+          Resource = "arn:aws:autoscaling:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:autoScalingGroup:*:autoScalingGroupName/${var.asg_name}"
+        }
+      ],
+      var.sns_topic_arn != "" ? [
+        {
+          Sid      = "PublishSNS"
+          Effect   = "Allow"
+          Action   = ["sns:Publish"]
+          Resource = var.sns_topic_arn
+        }
+      ] : []
+    )
+  })
+
+  tags = local.common_tags
+}
+
+# -----------------------------------------------------------------------------
+# Lambda Function
+# -----------------------------------------------------------------------------
+
+#tfsec:ignore:aws-lambda-enable-tracing
+module "lambda" {
+  source  = "terraform-aws-modules/lambda/aws"
+  version = "8.8.0"
+
+  function_name = local.function_name
+  description   = "Checks for new AMIs and triggers instance refresh for ${var.name_suffix}"
+  handler       = "ami_updater.handler"
+  runtime       = "nodejs22.x"
+  timeout       = 120
+  source_path   = "${path.module}/ami_updater.mjs"
+
+  trigger_on_package_timestamp = false
+
+  create_current_version_allowed_triggers = false
+  cloudwatch_logs_retention_in_days       = 30
+
+  attach_policies    = true
+  policies           = [aws_iam_policy.lambda_ami_updater.arn]
+  number_of_policies = 1
+
+  environment_variables = {
+    LAUNCH_TEMPLATE_ID     = var.launch_template_id
+    ASG_NAME               = var.asg_name
+    AMI_OWNERS             = jsonencode(var.ami_owners)
+    AMI_NAME_FILTER        = var.ami_name_filter
+    AMI_ARCHITECTURE       = var.ami_architecture
+    AMI_ADDITIONAL_FILTERS = jsonencode(var.ami_additional_filters)
+    MIN_HEALTHY_PERCENTAGE = tostring(var.min_healthy_percentage)
+    INSTANCE_WARMUP        = tostring(var.instance_warmup_seconds)
+    SNS_TOPIC_ARN          = var.sns_topic_arn
+  }
+
+  allowed_triggers = {
+    AmiCheckSchedule = {
+      principal  = "events.amazonaws.com"
+      source_arn = module.eventbridge.eventbridge_rule_arns["ami_check"]
+    }
+  }
+
+  tags = local.common_tags
+}
+
+# -----------------------------------------------------------------------------
+# EventBridge Schedule
+# -----------------------------------------------------------------------------
+
+module "eventbridge" {
+  source  = "terraform-aws-modules/eventbridge/aws"
+  version = "4.3.0"
+
+  create_bus = false
+
+  rules = {
+    ami_check = {
+      description         = "Periodic AMI update check for ${var.name_suffix}"
+      schedule_expression = var.schedule_expression
+    }
+  }
+
+  targets = {
+    ami_check = [
+      {
+        name = "${local.function_name}-target"
+        arn  = module.lambda.lambda_function_arn
+      }
+    ]
+  }
+
+  tags = local.common_tags
+}

--- a/modules/ami_update_automation/main.tf
+++ b/modules/ami_update_automation/main.tf
@@ -83,7 +83,7 @@ module "lambda" {
   function_name = local.function_name
   description   = "Checks for new AMIs and triggers instance refresh for ${var.name_suffix}"
   handler       = "ami_updater.handler"
-  runtime       = "nodejs22.x"
+  runtime       = "nodejs24.x"
   timeout       = 120
   source_path   = "${path.module}/ami_updater.mjs"
 

--- a/modules/ami_update_automation/outputs.tf
+++ b/modules/ami_update_automation/outputs.tf
@@ -1,0 +1,19 @@
+output "lambda_function_arn" {
+  description = "ARN of the AMI updater Lambda function"
+  value       = module.lambda.lambda_function_arn
+}
+
+output "lambda_function_name" {
+  description = "Name of the AMI updater Lambda function"
+  value       = module.lambda.lambda_function_name
+}
+
+output "eventbridge_rule_arn" {
+  description = "ARN of the EventBridge rule that triggers AMI checks"
+  value       = module.eventbridge.eventbridge_rule_arns["ami_check"]
+}
+
+output "lambda_log_group_name" {
+  description = "CloudWatch log group for the AMI updater Lambda"
+  value       = module.lambda.lambda_cloudwatch_log_group_name
+}

--- a/modules/ami_update_automation/outputs.tf
+++ b/modules/ami_update_automation/outputs.tf
@@ -10,7 +10,7 @@ output "lambda_function_name" {
 
 output "eventbridge_rule_arn" {
   description = "ARN of the EventBridge rule that triggers AMI checks"
-  value       = module.eventbridge.eventbridge_rule_arns["ami_check"]
+  value       = module.eventbridge.eventbridge_rule_arns[local.function_name]
 }
 
 output "lambda_log_group_name" {

--- a/modules/ami_update_automation/variables.tf
+++ b/modules/ami_update_automation/variables.tf
@@ -1,0 +1,82 @@
+variable "solution_name" {
+  description = "Solution name for resource naming"
+  type        = string
+}
+
+variable "name_suffix" {
+  description = "Unique suffix to distinguish multiple instances of this module (e.g., 'bastion', 'docker-postgres')"
+  type        = string
+}
+
+variable "launch_template_id" {
+  description = "ID of the launch template to update with new AMI versions"
+  type        = string
+}
+
+variable "asg_name" {
+  description = "Name of the Auto Scaling Group to trigger instance refresh on"
+  type        = string
+}
+
+variable "ami_owners" {
+  description = "List of AMI owner account IDs or aliases (e.g., ['amazon'])"
+  type        = list(string)
+  default     = ["amazon"]
+}
+
+variable "ami_name_filter" {
+  description = "Name filter pattern for AMI lookup (e.g., 'al2023-ami-2023*')"
+  type        = string
+  default     = "al2023-ami-2023*"
+}
+
+variable "ami_architecture" {
+  description = "CPU architecture filter for AMI lookup"
+  type        = string
+  default     = "arm64"
+}
+
+variable "ami_additional_filters" {
+  description = "Additional filters for AMI lookup as a map of filter name to values"
+  type        = map(list(string))
+  default = {
+    "root-device-type"                 = ["ebs"]
+    "virtualization-type"              = ["hvm"]
+    "block-device-mapping.volume-type" = ["gp3"]
+  }
+}
+
+variable "schedule_expression" {
+  description = "EventBridge schedule expression for AMI check (cron or rate)"
+  type        = string
+  default     = "rate(7 days)"
+}
+
+variable "min_healthy_percentage" {
+  description = "Minimum healthy percentage during instance refresh (0-100). For single-instance ASGs, use 0."
+  type        = number
+  default     = 0
+
+  validation {
+    condition     = var.min_healthy_percentage >= 0 && var.min_healthy_percentage <= 100
+    error_message = "min_healthy_percentage must be between 0 and 100."
+  }
+}
+
+variable "instance_warmup_seconds" {
+  description = "Number of seconds to wait for a new instance to be ready before continuing the refresh"
+  type        = number
+  default     = 300
+}
+
+variable "sns_topic_arn" {
+  description = "Optional SNS topic ARN for notifications on AMI updates. If empty, no notifications are sent."
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Additional tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/ami_update_automation/variables.tf
+++ b/modules/ami_update_automation/variables.tf
@@ -31,9 +31,9 @@ variable "ami_name_filter" {
 }
 
 variable "ami_architecture" {
-  description = "CPU architecture filter for AMI lookup"
+  description = "CPU architecture filter for AMI lookup. Set to 'auto' to derive from the current launch template's AMI."
   type        = string
-  default     = "arm64"
+  default     = "auto"
 }
 
 variable "ami_additional_filters" {

--- a/modules/bastion_host_ssm/main.tf
+++ b/modules/bastion_host_ssm/main.tf
@@ -130,3 +130,19 @@ resource "aws_iam_role_policy_attachment" "ssm_managed_instance_role_attach" {
   role       = aws_iam_role.ssm_managed_instance_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# AMI Update Automation
+# ---------------------------------------------------------------------------------------------------------------------
+
+module "ami_update" {
+  count  = var.enable_ami_updates ? 1 : 0
+  source = "../ami_update_automation"
+
+  solution_name       = var.solution_name
+  name_suffix         = "bastion"
+  launch_template_id  = aws_launch_template.my_asg_launch_template.id
+  asg_name            = aws_autoscaling_group.my_autoscaling_group.name
+  schedule_expression = var.ami_update_schedule
+  sns_topic_arn       = var.ami_update_sns_topic_arn
+}

--- a/modules/bastion_host_ssm/outputs.tf
+++ b/modules/bastion_host_ssm/outputs.tf
@@ -17,3 +17,7 @@ output "bastion_host_autoscaling_group_desired_capacity" {
 output "bastion_host_autoscaling_group_arn" {
   value = aws_autoscaling_group.my_autoscaling_group.arn
 }
+
+output "launch_template_id" {
+  value = aws_launch_template.my_asg_launch_template.id
+}

--- a/modules/bastion_host_ssm/variables.tf
+++ b/modules/bastion_host_ssm/variables.tf
@@ -14,3 +14,25 @@ variable "private_subnets" {
   type        = list(string)
   description = "Private subnets of vpc."
 }
+
+# -----------------------------------------------
+# AMI Update Automation
+# -----------------------------------------------
+
+variable "enable_ami_updates" {
+  description = "Enable automated AMI updates via EventBridge + Lambda. Periodically checks for newer AMIs, updates the launch template, and triggers an instance refresh."
+  type        = bool
+  default     = false
+}
+
+variable "ami_update_schedule" {
+  description = "EventBridge schedule expression for AMI update checks (e.g., 'rate(7 days)' or 'cron(0 3 ? * SUN *)')"
+  type        = string
+  default     = "rate(7 days)"
+}
+
+variable "ami_update_sns_topic_arn" {
+  description = "Optional SNS topic ARN for AMI update notifications. If empty, no notifications are sent."
+  type        = string
+  default     = ""
+}

--- a/modules/ec2_docker_workload/main.tf
+++ b/modules/ec2_docker_workload/main.tf
@@ -642,3 +642,20 @@ resource "aws_backup_selection" "docker_workload" {
     aws_iam_role_policy.backup_ebs_policy
   ]
 }
+
+# -----------------------------------------------
+# AMI Update Automation
+# -----------------------------------------------
+
+module "ami_update" {
+  count  = var.enable_ami_updates ? 1 : 0
+  source = "../ami_update_automation"
+
+  solution_name       = var.solution_name
+  name_suffix         = var.instance_name
+  launch_template_id  = aws_launch_template.docker_workload.id
+  asg_name            = aws_autoscaling_group.docker_workload.name
+  schedule_expression = var.ami_update_schedule
+  sns_topic_arn       = var.ami_update_sns_topic_arn
+  tags                = var.tags
+}

--- a/modules/ec2_docker_workload/variables.tf
+++ b/modules/ec2_docker_workload/variables.tf
@@ -365,3 +365,25 @@ variable "health_check_grace_period" {
     error_message = "Health check grace period must be between 60 and 3600 seconds."
   }
 }
+
+# -----------------------------------------------
+# AMI Update Automation
+# -----------------------------------------------
+
+variable "enable_ami_updates" {
+  description = "Enable automated AMI updates via EventBridge + Lambda. Periodically checks for newer AMIs, updates the launch template, and triggers an instance refresh."
+  type        = bool
+  default     = false
+}
+
+variable "ami_update_schedule" {
+  description = "EventBridge schedule expression for AMI update checks (e.g., 'rate(7 days)' or 'cron(0 3 ? * SUN *)')"
+  type        = string
+  default     = "rate(7 days)"
+}
+
+variable "ami_update_sns_topic_arn" {
+  description = "Optional SNS topic ARN for AMI update notifications. If empty, no notifications are sent."
+  type        = string
+  default     = ""
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -92,3 +92,13 @@ output "internal_service_dns_zone_arn" {
   value       = try(module.internal_service_dns[0].zone_arn, "")
   description = "Route53 internal service DNS zone ARN"
 }
+
+output "bastion_host_launch_template_id" {
+  value       = try(module.bastion_host_ssm[0].launch_template_id, "")
+  description = "Launch template ID of the bastion host"
+}
+
+output "bastion_host_asg_name" {
+  value       = try(module.bastion_host_ssm[0].bastion_host_autoscaling_group_name, "")
+  description = "Auto Scaling Group name of the bastion host"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -246,6 +246,12 @@ variable "create_bastion_host" {
   default     = false
 }
 
+variable "enable_bastion_ami_updates" {
+  description = "Enable automated AMI updates for the bastion host. Periodically checks for newer AMIs and triggers an instance refresh."
+  type        = bool
+  default     = false
+}
+
 variable "create_database" {
   description = "Creates an AWS RDS MySQL database and gives access to it from ECS containers and the bastion host."
   type        = bool


### PR DESCRIPTION
The AMIs versions of terra3 controlled EC2 instances are not automatically updated - neither during deployment / terraforming nor at runtime.
This feature adds a module which allows to setup EventBridge scheduled Lambda function for any EC2 Instance (respectively the Launch Template) that updates the Launch Template and triggers instance renewal if new AMI version has been detected.
It also adds parameters that allows to enable end adjust the scheduling for the AMI update for the terra3 EC2 powered services (bastion host, ec2 docker workload).